### PR TITLE
Update HealthBar material shader and properties

### DIFF
--- a/AutomathonUnity/Assets/Game/Features/VFX/HealthBar/HealthBarMat.mat
+++ b/AutomathonUnity/Assets/Game/Features/VFX/HealthBar/HealthBarMat.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: HealthBarMat
-  m_Shader: {fileID: 4800000, guid: e260cfa7296ee7642b167f1eb5be5023, type: 3}
+  m_Shader: {fileID: 4800000, guid: 9b664820f32bedd42902412a851e4ce4, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
@@ -41,10 +41,23 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - _AlphaMul: 1
+    - _Aspect: 5.7
+    - _BorderThickness: 0.06
     - _EnableExternalAlpha: 0
+    - _Fill: 1
+    - _FillChip: 1
+    - _MidPoint: 0.5
+    - _Radius: 0.25
     - _ZWrite: 0
     m_Colors:
+    - _BackColor: {r: 0.079999976, g: 0.079999976, b: 0.09999997, a: 0.85}
+    - _BorderColor: {r: 0.02, g: 0.02, b: 0.03, a: 1}
+    - _ChipColor: {r: 1, g: 1, b: 1, a: 0.9}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _ColorFull: {r: 0.29999998, g: 0.85, b: 0.39999998, a: 1}
+    - _ColorLow: {r: 0.9, g: 0.24999997, b: 0.24999997, a: 1}
+    - _ColorMid: {r: 0.95, g: 0.8, b: 0.24999997, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1


### PR DESCRIPTION
Change HealthBarMat to reference a new shader GUID and add several material parameters for enhanced visuals. New floats include _AlphaMul, _Aspect, _BorderThickness, _Fill, _FillChip, _MidPoint, and _Radius; new color properties include _BackColor, _BorderColor, _ChipColor, _ColorFull, _ColorLow, and _ColorMid. These additions enable border, chip, fill behavior and multi-state coloring for the health bar (file: AutomathonUnity/Assets/Game/Features/VFX/HealthBar/HealthBarMat.mat).