### PR TITLE
missile movement towards mouse

### DIFF
--- a/AutomathonUnity/Assets/Core/Game/Missile.cs
+++ b/AutomathonUnity/Assets/Core/Game/Missile.cs
@@ -76,7 +76,16 @@ namespace Automathon.Game
 
             if (AIMED)
             {
-                int goalRotationMilli = Atan2Int.Atan2(shotFromTank.LastMilliDirection.X, shotFromTank.LastMilliDirection.Y);
+                Vector2Int missileDirection;
+                if (shotFromTank.IsPlayingKeyboardLeft)
+                {
+                    missileDirection = shotFromTank.PlayerInputProvider.GetMousePos() - Position;//doesn't need to be normalised, would be cleaner but slower
+                }
+                else
+                {
+                    missileDirection = shotFromTank.LastMilliDirection;
+                }
+                int goalRotationMilli = Atan2Int.Atan2(missileDirection.X, missileDirection.Y);
                 int step = goalRotationMilli - RotationMilli;
 
                 if (step > IntMath.PI_MILLI)

--- a/AutomathonUnity/Assets/Core/Game/Tank.cs
+++ b/AutomathonUnity/Assets/Core/Game/Tank.cs
@@ -45,6 +45,9 @@ namespace Automathon.Game
         public bool IsReady { get; set; }
         public bool IsDashing { get; set; }
 
+        public bool IsPlayingKeyboardLeft { get; set; }
+        public PlayerInputProvider PlayerInputProvider { get; set; }
+
         public Tank(TeamType team, Vector2Int position, InputProvider inputProvider) : base(position)
         {
             InputProvider = inputProvider;
@@ -66,6 +69,16 @@ namespace Automathon.Game
                 //GrenadeAbility = new GrenadeAbility(inputProvider.ShouldGrenade),
                 Health = new Health(MAX_HEALTH, false, Death)
                 );
+
+            if (inputProvider is PlayerInputProvider p && p.ControlsType == PlayerInputProvider.PlayerControlsType.LeftKeyboard)
+            {
+                IsPlayingKeyboardLeft = true;
+                PlayerInputProvider = p;
+            }
+            else
+            {
+                IsPlayingKeyboardLeft = false;
+            }
         }
 
         public override void Update()

--- a/AutomathonUnity/Assets/Game/Features/Input/PlayerInputProvider.cs
+++ b/AutomathonUnity/Assets/Game/Features/Input/PlayerInputProvider.cs
@@ -90,5 +90,14 @@ namespace Automathon.Game.Input
 
             return readInput.ToVector2IntScaled();
         }
+
+        public Vector2Int GetMousePos()
+        {
+            if (ControlsType != PlayerControlsType.LeftKeyboard)
+                return Vector2Int.Zero;
+            Vector2 readInput = aimAction.ReadValue<Vector2>();
+            Vector2 mouseWorldPos = readInput.ScreenToWorldSpace();
+            return mouseWorldPos.ToVector2IntScaled();
+        }
     }
 }


### PR DESCRIPTION
shooting also towards mouse, which induces a different behaviour than for controllers. Should this be changed or not, given that the keyboard controls are destined for playtesting only ?